### PR TITLE
BUGFIX Unset field from constraints array

### DIFF
--- a/code/ZenValidator.php
+++ b/code/ZenValidator.php
@@ -222,6 +222,7 @@ class ZenValidator extends Validator{
 			foreach ($constraints as $k => $v) {
 				$this->removeConstraint($fieldName, $k);
 			}
+			unset($this->constraints[$fieldName]);
 		}
 		return $this;
 	}


### PR DESCRIPTION
Currently `removeConstraints` removes all the constraints but leaves the field name in the `$constraints` array which causes issues. This just tidies that up.
