### PR TITLE
on match for hidden forms

### DIFF
--- a/javascript/zenvalidator.js
+++ b/javascript/zenvalidator.js
@@ -1,7 +1,11 @@
 (function($) {
 	$.entwine('ss.zenvalidator', function($) {
-		$('form.parsley').parsley({
-			 excluded: 'input[type=button], input[type=submit], input[type=reset], input[type=hidden], :hidden, .ignore-validation'
+		$('form.parsley').entwine({
+			onmatch: function() {
+        			$(this).parsley({
+            				excluded: 'input[type=button], input[type=submit], input[type=reset], input[type=hidden], :hidden, .ignore-validation'
+        			});
+			}
 		});
 
 		$('.field').entwine({


### PR DESCRIPTION
If a form is in a panel (eg foundations tabs) the js will still validate when the form is revealed & the user clicks submit - because of the onmatch wrapper.
