### PR TITLE
Using empty with eval was a bad idea

### DIFF
--- a/code/ValidationLogicCriterion.php
+++ b/code/ValidationLogicCriterion.php
@@ -99,7 +99,7 @@ class ValidationLogicCriterion extends Object {
 				return "$value1 == \"1\"";
 			
 			case 'Empty':
-				return 'empty(' . $value1 . ')';
+				return $value1 . '==""';
 				
 			default:
 				user_error("ValidationLogicCriteria: php operator \"$this->operator\" not configured.",E_USER_ERROR);


### PR DESCRIPTION
Replace empty with a simple == ""
