### PR TITLE
if conditional logic changes

### DIFF
--- a/javascript/zenvalidator.js
+++ b/javascript/zenvalidator.js
@@ -170,6 +170,11 @@
 
 		$('.field.validation-logic.validation-logic-exclude').entwine({
 			testLogic: function() {
+				if(!this.parseLogic()){					
+					this.find('ul.parsley-errors-list').hide();
+				}else{
+					this.find('ul.parsley-errors-list').show();
+				}
 				this.getFormField().toggleClass('ignore-validation', !this.parseLogic());
 			}
 		});


### PR DESCRIPTION
The error messages are no longer valid.  Just a repeat of earlier patch.  Probably a terrible way to do it.