### PR TITLE
Fix broken type hinting in ValidationLogicCriteria

### DIFF
--- a/code/ValidationLogicCriteria.php
+++ b/code/ValidationLogicCriteria.php
@@ -62,7 +62,7 @@ class ValidationLogicCriteria extends Object {
 	 * @param [type]    $master The name of the form field to respond to
 	 * @param [type]    $parent The parent {@link ValidationLogicCriteria}
 	 */
-	public function __construct(ZenValidatorConstraint $slave, $master, $parent = null) {
+	public function __construct(FormField $slave, $master, $parent = null) {
 		parent::__construct();
 		$this->slave = $slave;
 		$this->master = $master;


### PR DESCRIPTION
This is actually causing behat to fail on my project. It only works in SilverStripe because `E_RECOVERABLE_ERROR` is silently ignored currently (see https://github.com/silverstripe/silverstripe-framework/issues/2928), I’m guessing behat has its own error handlers