### PR TITLE
Fix zero min validation bug

### DIFF
--- a/code/ZenValidatorConstraint.php
+++ b/code/ZenValidatorConstraint.php
@@ -421,7 +421,7 @@ class Constraint_value extends ZenValidatorConstraint {
 	}
 
 	function validate($value) {
-		if (!$value)
+		if (!is_numeric($value))
 			return true;
 
 		switch ($this->type) {

--- a/tests/ZenValidatorConstraintTest.php
+++ b/tests/ZenValidatorConstraintTest.php
@@ -113,6 +113,15 @@ class ZenValidatorConstraintTest extends SapphireTest{
 		$zv->php($data);
 		$errors = $zv->getErrors();
 		$this->assertTrue($errors[0]['fieldName'] == 'Title');
+		
+		$zv = $this->Form()->getValidator();
+		$zv->setConstraint('Title', Constraint_value::create('min', 5));
+
+		//test zero is invalid
+		$data['Title'] = '0';
+		$zv->php($data);
+		$errors = $zv->getErrors();
+		$this->assertTrue($errors[0]['fieldName'] == 'Title');
 	}
 
 


### PR DESCRIPTION
Hi, 

This fixes a bug where the if (!$value) check in Constraint_value validate() caused no validation to be fired if the value was 0 (ie; valid, but falseish). 

eg; without this fix a validation constraint of 

$zv->setConstraint('Field', Constraint_value::create('min', 5))

Would not return an error if the value was 0.

I've changed it to check if it's numeric and also added a unit test.

Cheers,
Dan