### PR TITLE
Image size validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,60 +310,70 @@ You can add constraints to image selection/upload fields to ensure that users ar
 Note: the validation is run when the page is saved, not at time of image choosing or upload.
 
 Width
+
 Use this to require the width of an image to be a certain number of pixels. Handy if you require images to be an exact size.
 ```php
 $validator->setConstraint('HeroImage', Constraint_dimension::create('width', 100));
 ```
 
 Height
+
 Use this to require the height of an image is the specified pixels.
 ```php
 $validator->setConstraint('HeroImage', Constraint_dimension::create('height', 150));
 ```
 
 Width and Height
+
 Use this to require both the width and height are the specified pixels.
 ```php
 $validator->setConstraint('HeroImage', Constraint_dimension::create('width_height', 100, 150));
 ```
 
 Ratio
+
 Use this to require images to be a certain shape, for example 6:4 photo, 5:5 square etc. Handy when you need an image to be a particular shape but are relaxed about the size as that might be dealt with by CSS.
 ```php
 $validator->setConstraint('HeroImage', Constraint_dimension::create('ratio', 16, 9));
 ```
 
 Min width
+
 Use this to ensure the width of an image is equal to or greater than the specified pixels, handy to ensure that users don't use images which are too small and might loose quality if stretched by CSS.
 ```php
 $validator->setConstraint('HeroImage', Constraint_dimension::create('min_width', 50));
 ```
 
 Min height
+
 Use this to ensure that the height of an image is equal to or greater than the specified pixels.
 ```php
 $validator->setConstraint('HeroImage', Constraint_dimension::create('min_height', 75));
 ```
 
 Min width and height
+
 Use this to ensure that the width and the height of the image are equal to or greater than the specified pixels.
 ```php
 $validator->setConstraint('HeroImage', Constraint_dimension::create('min_width_height', 50, 75));
 ```
 
 Max width
+
 Use this to ensure that the width of an image is less than or equal to the specified pixels. Handy to ensure that users don't select images far larger than required, especially if these images have a max-width set by CSS as that would result in a lot of wasted bandwidth.
 ```php
 $validator->setConstraint('HeroImage', Constraint_dimension::create('max_width', 300));
 ```
 
 Max height
+
 Use this to ensure the height of an image is less than or equal to the specified pixels.
 ```php
 $validator->setConstraint('HeroImage', Constraint_dimension::create('max_height', 200));
 ```
 
 Max width and height
+
 Use this to ensure the width and height is of an image does not exceed the specified pixels.
 ```php
 $validator->setConstraint('HeroImage', Constraint_dimension::create('max_width_height', 300, 200));

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Out of the box constraints include:
 * equalto (equal to the value of another field)
 * regex
 * remote (validate remotely via ajax)
+* dimension (image width, height, aspect ratio. CMS only)
 
 
 ## Usage examples

--- a/README.md
+++ b/README.md
@@ -303,76 +303,76 @@ public function getCMSValidator(){
     $validator->disableParsley();
 }
 ```
-##### Image Dimension Constraints (CMS only)
+#### Image Dimension Constraints (CMS only)
 
 You can add constraints to image selection/upload fields to ensure that users are saving images of the correct size or shape, or that the image is of a minimum/maximum width and height to prevent issues with the display of the image in the site.
 
 Note: the validation is run when the page is saved, not at time of image choosing or upload.
 
-Width
+##### Width
 
 Use this to require the width of an image to be a certain number of pixels. Handy if you require images to be an exact size.
 ```php
 $validator->setConstraint('HeroImage', Constraint_dimension::create('width', 100));
 ```
 
-Height
+##### Height
 
 Use this to require the height of an image is the specified pixels.
 ```php
 $validator->setConstraint('HeroImage', Constraint_dimension::create('height', 150));
 ```
 
-Width and Height
+##### Width and Height
 
 Use this to require both the width and height are the specified pixels.
 ```php
 $validator->setConstraint('HeroImage', Constraint_dimension::create('width_height', 100, 150));
 ```
 
-Ratio
+##### Ratio
 
 Use this to require images to be a certain shape, for example 6:4 photo, 5:5 square etc. Handy when you need an image to be a particular shape but are relaxed about the size as that might be dealt with by CSS.
 ```php
 $validator->setConstraint('HeroImage', Constraint_dimension::create('ratio', 16, 9));
 ```
 
-Min width
+##### Min width
 
 Use this to ensure the width of an image is equal to or greater than the specified pixels, handy to ensure that users don't use images which are too small and might loose quality if stretched by CSS.
 ```php
 $validator->setConstraint('HeroImage', Constraint_dimension::create('min_width', 50));
 ```
 
-Min height
+##### Min height
 
 Use this to ensure that the height of an image is equal to or greater than the specified pixels.
 ```php
 $validator->setConstraint('HeroImage', Constraint_dimension::create('min_height', 75));
 ```
 
-Min width and height
+##### Min width and height
 
 Use this to ensure that the width and the height of the image are equal to or greater than the specified pixels.
 ```php
 $validator->setConstraint('HeroImage', Constraint_dimension::create('min_width_height', 50, 75));
 ```
 
-Max width
+##### Max width
 
 Use this to ensure that the width of an image is less than or equal to the specified pixels. Handy to ensure that users don't select images far larger than required, especially if these images have a max-width set by CSS as that would result in a lot of wasted bandwidth.
 ```php
 $validator->setConstraint('HeroImage', Constraint_dimension::create('max_width', 300));
 ```
 
-Max height
+##### Max height
 
 Use this to ensure the height of an image is less than or equal to the specified pixels.
 ```php
 $validator->setConstraint('HeroImage', Constraint_dimension::create('max_height', 200));
 ```
 
-Max width and height
+##### Max width and height
 
 Use this to ensure the width and height is of an image does not exceed the specified pixels.
 ```php

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Out of the box constraints include:
 
 ## Usage examples
 
-### Create a form, add ZenValidator.
+### Create a form, add ZenValidator.  
 
 ```php
 public function Form(){
@@ -176,7 +176,7 @@ $validator->setConstraint('FavoriteColor', Constraint_regex::create("/^#(?:[0-9a
 
 ##### Remote validation
 
-Validate based on the response from a remote url. The following are valid responses from the remote url, with a 200 response code: 1, true, { "success": "..." } and assume false otherwise. You can show a specific specific error message by returning { "error": "your custom message" } or { "message": "your custom message" }
+Validate based on the response from a remote url. The following are valid responses from the remote url, with a 200 response code: 1, true, { "success": "..." } and assume false otherwise. You can show a specific specific error message by returning { "error": "your custom message" } or { "message": "your custom message" } 
 
 ```php
 $validator->setConstraint('Username', Constraint_remote::create($this->Link('checkusername')));
@@ -287,7 +287,6 @@ $.each($('form.parsley').parsley(),function(i,parsleyForm) {
 
 See [Parsley.js](http://parsleyjs.org/doc/index.html) for the full list of configuration settings
 
-
 ### CMS Usage
 
 To use ZenValidator in the CMS, simply implement a getCMSValidator() method on your custom Page type or DataObject class
@@ -303,7 +302,61 @@ public function getCMSValidator(){
     $validator->disableParsley();
 }
 ```
+##### Image Dimension Constraints (CMS only)
 
+You can add constraints to image selection/upload fields to ensure that users are saving images of the correct size or shape, or that the image is of a minimum/maximum width and height to prevent issues with the display of the image in the site.
+
+Note: the validation is run when the page is saved, not at time of image choosing or upload.
+
+Width
+```php
+$validator->setConstraint('HeroImage', Constraint_dimension::create('width', 100));
+```
+
+Height
+```php
+$validator->setConstraint('HeroImage', Constraint_dimension::create('height', 150));
+```
+
+Width and Height
+```php
+$validator->setConstraint('HeroImage', Constraint_dimension::create('width_height', 100, 150));
+```
+
+Ratio
+```php
+$validator->setConstraint('HeroImage', Constraint_dimension::create('ratio', 16, 9));
+```
+
+Min width
+```php
+$validator->setConstraint('HeroImage', Constraint_dimension::create('min_width', 50));
+```
+
+Min height
+```php
+$validator->setConstraint('HeroImage', Constraint_dimension::create('min_height', 75));
+```
+
+Min width and height
+```php
+$validator->setConstraint('HeroImage', Constraint_dimension::create('min_width_height', 50, 75));
+```
+
+Max width
+```php
+$validator->setConstraint('HeroImage', Constraint_dimension::create('max_width', 300));
+```
+
+Max height
+```php
+$validator->setConstraint('HeroImage', Constraint_dimension::create('max_height', 200));
+```
+
+Max width and height
+```php
+$validator->setConstraint('HeroImage', Constraint_dimension::create('max_width_height', 300, 200));
+```
 
 ## Validation Logic - Conditional Constraints
 

--- a/README.md
+++ b/README.md
@@ -310,51 +310,61 @@ You can add constraints to image selection/upload fields to ensure that users ar
 Note: the validation is run when the page is saved, not at time of image choosing or upload.
 
 Width
+Use this to require the width of an image to be a certain number of pixels. Handy if you require images to be an exact size.
 ```php
 $validator->setConstraint('HeroImage', Constraint_dimension::create('width', 100));
 ```
 
 Height
+Use this to require the height of an image is the specified pixels.
 ```php
 $validator->setConstraint('HeroImage', Constraint_dimension::create('height', 150));
 ```
 
 Width and Height
+Use this to require both the width and height are the specified pixels.
 ```php
 $validator->setConstraint('HeroImage', Constraint_dimension::create('width_height', 100, 150));
 ```
 
 Ratio
+Use this to require images to be a certain shape, for example 6:4 photo, 5:5 square etc. Handy when you need an image to be a particular shape but are relaxed about the size as that might be dealt with by CSS.
 ```php
 $validator->setConstraint('HeroImage', Constraint_dimension::create('ratio', 16, 9));
 ```
 
 Min width
+Use this to ensure the width of an image is equal to or greater than the specified pixels, handy to ensure that users don't use images which are too small and might loose quality if stretched by CSS.
 ```php
 $validator->setConstraint('HeroImage', Constraint_dimension::create('min_width', 50));
 ```
 
 Min height
+Use this to ensure that the height of an image is equal to or greater than the specified pixels.
 ```php
 $validator->setConstraint('HeroImage', Constraint_dimension::create('min_height', 75));
 ```
 
 Min width and height
+Use this to ensure that the width and the height of the image are equal to or greater than the specified pixels.
 ```php
 $validator->setConstraint('HeroImage', Constraint_dimension::create('min_width_height', 50, 75));
 ```
 
 Max width
+Use this to ensure that the width of an image is less than or equal to the specified pixels. Handy to ensure that users don't select images far larger than required, especially if these images have a max-width set by CSS as that would result in a lot of wasted bandwidth.
 ```php
 $validator->setConstraint('HeroImage', Constraint_dimension::create('max_width', 300));
 ```
 
 Max height
+Use this to ensure the height of an image is less than or equal to the specified pixels.
 ```php
 $validator->setConstraint('HeroImage', Constraint_dimension::create('max_height', 200));
 ```
 
 Max width and height
+Use this to ensure the width and height is of an image does not exceed the specified pixels.
 ```php
 $validator->setConstraint('HeroImage', Constraint_dimension::create('max_width_height', 300, 200));
 ```

--- a/code/ZenValidatorConstraint.php
+++ b/code/ZenValidatorConstraint.php
@@ -1082,8 +1082,6 @@ class Constraint_dimension extends ZenValidatorConstraint
     {
         // The value which comes in is a files array so we can look through this
         // to and then get the files to test aspects of them.
-        // @TODO does the normal upload field allow for multiple files
-        // think we are using speical one in the whitireia site.
         if (isset($value['Files'])) {
             foreach($value['Files'] as $fileID) {
                 $file = File::get()->byId($fileID);

--- a/code/ZenValidatorConstraint.php
+++ b/code/ZenValidatorConstraint.php
@@ -1063,6 +1063,12 @@ class Constraint_dimension extends ZenValidatorConstraint
     const HEIGHT = 'height';
     const WIDTH_HEIGHT = 'width_height';
     const RATIO = 'ratio';
+    const MIN_WIDTH = 'min_width';
+    const MIN_HEIGHT = 'min_height';
+    const MIN_WIDTH_HEIGHT = 'min_width_height';
+    const MAX_WIDTH = 'max_width';
+    const MAX_HEIGHT = 'max_height';
+    const MAX_WIDTH_HEIGHT = 'max_width_height';
 
     public function __construct($type,$val1,$val2=null)
     {
@@ -1096,21 +1102,48 @@ class Constraint_dimension extends ZenValidatorConstraint
                         $height = $info[1];
 
                         switch ($this->type) {
-                            case 'width':
-                                return $width == $this->val1 ? true : false;
+                            case self::WIDTH:
+                                return $width == $this->val1;
                                 break;
-                            case 'height':
-                                return $height == $this->val1 ? true : false;
+                            case self::HEIGHT:
+                                return $height == $this->val1;
                                 break;
-                            case 'width_height':
+                            case self::WIDTH_HEIGHT:
                                 if (($width == $this->val1) && ($height == $this->val2)) {
                                     return true;
                                 } else {
                                     return false;
                                 }
                                 break;
-                            case 'ratio':
+                            case self::RATIO:
                                 return $this->ratioValidation($width, $height);
+                                break;
+                            case self::MIN_WIDTH:
+                                return $width >= $this->val1;
+                                break;
+                            case self::MIN_HEIGHT:
+                                return $height >= $this->val1;
+                                break;
+                            case self::MIN_WIDTH_HEIGHT:
+                                if (($width >= $this->val1) && ($height >= $this->val2)) {
+                                    return true;
+                                } else {
+                                    return false;
+                                }
+                                break;
+                            case self::MAX_WIDTH:
+                                return $width <= $this->val1;
+                                break;
+                            case self::MAX_HEIGHT:
+                                return $height <= $this->val1;
+                                break;
+                            case self::MAX_WIDTH_HEIGHT:
+                                if (($width <= $this->val1) && ($height <= $this->val2)) {
+                                    return true;
+                                } else {
+                                    return false;
+                                }
+                                break;
                             default:
                                 throw new Exception('Invalid type : ' . $this->type);
                         }
@@ -1151,17 +1184,35 @@ class Constraint_dimension extends ZenValidatorConstraint
     public function getDefaultMessage()
     {
         switch ($this->type) {
-            case 'width':
+            case self::WIDTH:
                 return sprintf(_t('ZenValidator.DIMWIDTH', 'Image width must be %s pixles'), $this->val1);
                 break;
-            case 'height':
+            case self::HEIGHT:
                 return sprintf(_t('ZenValidator.DIMHEIGHT', 'Image height must be %s pixles'), $this->val1);
                 break;
-            case 'width_height':
+            case self::WIDTH_HEIGHT:
                 return sprintf(_t('ZenValidator.DIMWIDTHHEIGHT', 'Image width must be %s pixles and Image height must be %s pixles'), $this->val1, $this->val2);
                 break;
-            case 'ratio':
+            case self::RATIO:
                 return sprintf(_t('ZenValidator.DIMRATIO', 'Image aspect ratio (shape) must be %s:%s'), $this->val1, $this->val2);
+                break;
+            case self::MIN_WIDTH:
+                return sprintf(_t('ZenValidator.DIMMINWIDTH', 'Image width must be greater than or equal to %s pixles'), $this->val1);
+                break;
+            case self::MIN_HEIGHT:
+                return sprintf(_t('ZenValidator.DIMMINHEIGHT', 'Image height must be greater than or equal to %s pixles'), $this->val1);
+                break;
+            case self::MIN_WIDTH_HEIGHT:
+                return sprintf(_t('ZenValidator.DIMMINWIDTHHEIGHT', 'Image width must be greater than or equal to %s pixles and Image height must be greater than or equal to %s pixles'), $this->val1, $this->val2);
+                break;
+            case self::MAX_WIDTH:
+                return sprintf(_t('ZenValidator.DIMMAXWIDTH', 'Image width must be less than or equal to %s pixles'), $this->val1);
+                break;
+            case self::MAX_HEIGHT:
+                return sprintf(_t('ZenValidator.DIMMAXHEIGHT', 'Image height must be less than or equal to %s pixles'), $this->val1);
+                break;
+            case self::MAX_WIDTH_HEIGHT:
+                return sprintf(_t('ZenValidator.DIMMAXWIDTHHEIGHT', 'Image width must be less than or equal to %s pixles and Image height must be less than or equal to %s pixles'), $this->val1, $this->val2);
                 break;
         }
     }

--- a/code/ZenValidatorConstraint.php
+++ b/code/ZenValidatorConstraint.php
@@ -1055,10 +1055,24 @@ class Constraint_date extends ZenValidatorConstraint
  * */
 class Constraint_dimension extends ZenValidatorConstraint
 {
+    /**
+     * @var String
+     */
     protected $type;
+
+    /**
+     * @var Int
+     */
     protected $val1;
+
+    /**
+     * @var Int
+     */
     protected $val2;
 
+    /**
+     * Validation type constants.
+     */
     const WIDTH = 'width';
     const HEIGHT = 'height';
     const WIDTH_HEIGHT = 'width_height';
@@ -1070,6 +1084,12 @@ class Constraint_dimension extends ZenValidatorConstraint
     const MAX_HEIGHT = 'max_height';
     const MAX_WIDTH_HEIGHT = 'max_width_height';
 
+    /**
+     * Constructor
+     * @param String $type Type of validation
+     * @param Int $val1 First value
+     * @param Int $val2 Second value
+     */
     public function __construct($type,$val1,$val2=null)
     {
         $this->type = $type;
@@ -1095,7 +1115,7 @@ class Constraint_dimension extends ZenValidatorConstraint
                 // Now have the file double-check it is an image and if so then
                 // get some information about the image using PHPs getimagesize()
                 if ($file->ClassName == 'Image') {
-                    $info = getimagesize($_SERVER['DOCUMENT_ROOT'] . "/" . $file->Filename);
+                    $info = getimagesize(BASE_PATH . "/" . $file->Filename);
 
                     if ($info && is_array($info)) {
                         $width = $info[0];
@@ -1109,11 +1129,7 @@ class Constraint_dimension extends ZenValidatorConstraint
                                 return $height == $this->val1;
                                 break;
                             case self::WIDTH_HEIGHT:
-                                if (($width == $this->val1) && ($height == $this->val2)) {
-                                    return true;
-                                } else {
-                                    return false;
-                                }
+                                return (($width == $this->val1) && ($height == $this->val2));
                                 break;
                             case self::RATIO:
                                 return $this->ratioValidation($width, $height);
@@ -1125,11 +1141,7 @@ class Constraint_dimension extends ZenValidatorConstraint
                                 return $height >= $this->val1;
                                 break;
                             case self::MIN_WIDTH_HEIGHT:
-                                if (($width >= $this->val1) && ($height >= $this->val2)) {
-                                    return true;
-                                } else {
-                                    return false;
-                                }
+                                return (($width >= $this->val1) && ($height >= $this->val2));
                                 break;
                             case self::MAX_WIDTH:
                                 return $width <= $this->val1;
@@ -1138,11 +1150,7 @@ class Constraint_dimension extends ZenValidatorConstraint
                                 return $height <= $this->val1;
                                 break;
                             case self::MAX_WIDTH_HEIGHT:
-                                if (($width <= $this->val1) && ($height <= $this->val2)) {
-                                    return true;
-                                } else {
-                                    return false;
-                                }
+                                return (($width <= $this->val1) && ($height <= $this->val2));
                                 break;
                             default:
                                 throw new Exception('Invalid type : ' . $this->type);
@@ -1151,8 +1159,6 @@ class Constraint_dimension extends ZenValidatorConstraint
                 }
             }
         }
-
-        exit();
     }
 
     /**
@@ -1185,34 +1191,98 @@ class Constraint_dimension extends ZenValidatorConstraint
     {
         switch ($this->type) {
             case self::WIDTH:
-                return sprintf(_t('ZenValidator.DIMWIDTH', 'Image width must be %s pixles'), $this->val1);
+                return sprintf(
+                    _t(
+                        'ZenValidator.DIMWIDTH',
+                        'Image width must be %s pixles'
+                    ),
+                    $this->val1
+                );
                 break;
             case self::HEIGHT:
-                return sprintf(_t('ZenValidator.DIMHEIGHT', 'Image height must be %s pixles'), $this->val1);
+                return sprintf(
+                    _t(
+                        'ZenValidator.DIMHEIGHT',
+                        'Image height must be %s pixles'
+                    ),
+                    $this->val1
+                );
                 break;
             case self::WIDTH_HEIGHT:
-                return sprintf(_t('ZenValidator.DIMWIDTHHEIGHT', 'Image width must be %s pixles and Image height must be %s pixles'), $this->val1, $this->val2);
+                return sprintf(
+                    _t(
+                        'ZenValidator.DIMWIDTHHEIGHT',
+                        'Image width must be %s pixles and Image height must be %s pixles'
+                    ),
+                    $this->val1,
+                    $this->val2
+                );
                 break;
             case self::RATIO:
-                return sprintf(_t('ZenValidator.DIMRATIO', 'Image aspect ratio (shape) must be %s:%s'), $this->val1, $this->val2);
+                return sprintf(
+                    _t(
+                        'ZenValidator.DIMRATIO',
+                        'Image aspect ratio (shape) must be %s:%s'
+                    ),
+                    $this->val1,
+                    $this->val2
+                );
                 break;
             case self::MIN_WIDTH:
-                return sprintf(_t('ZenValidator.DIMMINWIDTH', 'Image width must be greater than or equal to %s pixles'), $this->val1);
+                return sprintf(
+                    _t(
+                        'ZenValidator.DIMMINWIDTH',
+                        'Image width must be greater than or equal to %s pixles'
+                    ),
+                    $this->val1
+                );
                 break;
             case self::MIN_HEIGHT:
-                return sprintf(_t('ZenValidator.DIMMINHEIGHT', 'Image height must be greater than or equal to %s pixles'), $this->val1);
+                return sprintf(
+                    _t(
+                        'ZenValidator.DIMMINHEIGHT',
+                        'Image height must be greater than or equal to %s pixles'
+                    ),
+                    $this->val1
+                );
                 break;
             case self::MIN_WIDTH_HEIGHT:
-                return sprintf(_t('ZenValidator.DIMMINWIDTHHEIGHT', 'Image width must be greater than or equal to %s pixles and Image height must be greater than or equal to %s pixles'), $this->val1, $this->val2);
+                return sprintf(
+                    _t(
+                        'ZenValidator.DIMMINWIDTHHEIGHT',
+                        'Image width must be greater than or equal to %s pixles and Image height must be greater than or equal to %s pixles'
+                    ),
+                    $this->val1,
+                    $this->val2
+                );
                 break;
             case self::MAX_WIDTH:
-                return sprintf(_t('ZenValidator.DIMMAXWIDTH', 'Image width must be less than or equal to %s pixles'), $this->val1);
+                return sprintf(
+                    _t(
+                        'ZenValidator.DIMMAXWIDTH',
+                        'Image width must be less than or equal to %s pixles'
+                    ),
+                    $this->val1
+                );
                 break;
             case self::MAX_HEIGHT:
-                return sprintf(_t('ZenValidator.DIMMAXHEIGHT', 'Image height must be less than or equal to %s pixles'), $this->val1);
+                return sprintf(
+                    _t(
+                        'ZenValidator.DIMMAXHEIGHT',
+                        'Image height must be less than or equal to %s pixles'
+                    ),
+                    $this->val1
+                );
                 break;
             case self::MAX_WIDTH_HEIGHT:
-                return sprintf(_t('ZenValidator.DIMMAXWIDTHHEIGHT', 'Image width must be less than or equal to %s pixles and Image height must be less than or equal to %s pixles'), $this->val1, $this->val2);
+                return sprintf(
+                    _t(
+                        'ZenValidator.DIMMAXWIDTHHEIGHT',
+                        'Image width must be less than or equal to %s pixles and Image height must be less than or equal to %s pixles'
+                    ),
+                    $this->val1,
+                    $this->val2
+                );
                 break;
         }
     }

--- a/code/ZenValidatorConstraint.php
+++ b/code/ZenValidatorConstraint.php
@@ -1132,7 +1132,9 @@ class Constraint_dimension extends ZenValidatorConstraint
                                 return (($width == $this->val1) && ($height == $this->val2));
                                 break;
                             case self::RATIO:
-                                return $this->ratioValidation($width, $height);
+                                $baseWidth = floor($width / $this->val1);
+                                $baseHeight = floor($height / $this->val2);
+                                return $baseWidth == $baseHeight;
                                 break;
                             case self::MIN_WIDTH:
                                 return $width >= $this->val1;
@@ -1159,28 +1161,6 @@ class Constraint_dimension extends ZenValidatorConstraint
                 }
             }
         }
-    }
-
-    /**
-     * Does the ratio validation
-     * @param  Int $width  width of the image
-     * @param  Int $height height of the image
-     * @return boolean
-     */
-    protected function ratioValidation($width,$height)
-    {
-        $validationResult = false;
-
-        // Divide the width and height by the ratio, ignore the decimal points as can't have part pixels.
-        $baseWidth = floor($width / $this->val1);
-        $baseHeight = floor($height / $this->val2);
-
-        // Compare the base values, if they match then the image is in the correct aspect ratio.
-        if ($baseWidth == $baseHeight) {
-            $validationResult = true;
-        }
-
-        return $validationResult;
     }
 
     /**

--- a/code/ZenValidatorConstraint.php
+++ b/code/ZenValidatorConstraint.php
@@ -1171,7 +1171,7 @@ class Constraint_dimension extends ZenValidatorConstraint
     {
         $validationResult = false;
 
-        // Divide the width and height by the ratio, ignore the decimal points as can't have part pixles.
+        // Divide the width and height by the ratio, ignore the decimal points as can't have part pixels.
         $baseWidth = floor($width / $this->val1);
         $baseHeight = floor($height / $this->val2);
 
@@ -1194,7 +1194,7 @@ class Constraint_dimension extends ZenValidatorConstraint
                 return sprintf(
                     _t(
                         'ZenValidator.DIMWIDTH',
-                        'Image width must be %s pixles'
+                        'Image width must be %s pixels'
                     ),
                     $this->val1
                 );
@@ -1203,7 +1203,7 @@ class Constraint_dimension extends ZenValidatorConstraint
                 return sprintf(
                     _t(
                         'ZenValidator.DIMHEIGHT',
-                        'Image height must be %s pixles'
+                        'Image height must be %s pixels'
                     ),
                     $this->val1
                 );
@@ -1212,7 +1212,7 @@ class Constraint_dimension extends ZenValidatorConstraint
                 return sprintf(
                     _t(
                         'ZenValidator.DIMWIDTHHEIGHT',
-                        'Image width must be %s pixles and Image height must be %s pixles'
+                        'Image width must be %s pixels and Image height must be %s pixels'
                     ),
                     $this->val1,
                     $this->val2
@@ -1232,7 +1232,7 @@ class Constraint_dimension extends ZenValidatorConstraint
                 return sprintf(
                     _t(
                         'ZenValidator.DIMMINWIDTH',
-                        'Image width must be greater than or equal to %s pixles'
+                        'Image width must be greater than or equal to %s pixels'
                     ),
                     $this->val1
                 );
@@ -1241,7 +1241,7 @@ class Constraint_dimension extends ZenValidatorConstraint
                 return sprintf(
                     _t(
                         'ZenValidator.DIMMINHEIGHT',
-                        'Image height must be greater than or equal to %s pixles'
+                        'Image height must be greater than or equal to %s pixels'
                     ),
                     $this->val1
                 );
@@ -1250,7 +1250,7 @@ class Constraint_dimension extends ZenValidatorConstraint
                 return sprintf(
                     _t(
                         'ZenValidator.DIMMINWIDTHHEIGHT',
-                        'Image width must be greater than or equal to %s pixles and Image height must be greater than or equal to %s pixles'
+                        'Image width must be greater than or equal to %s pixels and Image height must be greater than or equal to %s pixels'
                     ),
                     $this->val1,
                     $this->val2
@@ -1260,7 +1260,7 @@ class Constraint_dimension extends ZenValidatorConstraint
                 return sprintf(
                     _t(
                         'ZenValidator.DIMMAXWIDTH',
-                        'Image width must be less than or equal to %s pixles'
+                        'Image width must be less than or equal to %s pixels'
                     ),
                     $this->val1
                 );
@@ -1269,7 +1269,7 @@ class Constraint_dimension extends ZenValidatorConstraint
                 return sprintf(
                     _t(
                         'ZenValidator.DIMMAXHEIGHT',
-                        'Image height must be less than or equal to %s pixles'
+                        'Image height must be less than or equal to %s pixels'
                     ),
                     $this->val1
                 );
@@ -1278,7 +1278,7 @@ class Constraint_dimension extends ZenValidatorConstraint
                 return sprintf(
                     _t(
                         'ZenValidator.DIMMAXWIDTHHEIGHT',
-                        'Image width must be less than or equal to %s pixles and Image height must be less than or equal to %s pixles'
+                        'Image width must be less than or equal to %s pixels and Image height must be less than or equal to %s pixels'
                     ),
                     $this->val1,
                     $this->val2

--- a/code/ZenValidatorConstraint.php
+++ b/code/ZenValidatorConstraint.php
@@ -1144,6 +1144,10 @@ class Constraint_dimension extends ZenValidatorConstraint
         return $validationResult;
     }
 
+    /**
+     * Gets the default message for the validator
+     * @return String the validation message
+     */
     public function getDefaultMessage()
     {
         switch ($this->type) {


### PR DESCRIPTION
Added ability to set validator for image selection/upload fields (CMS side) so that users must choose an image of, for example, a specified minimum width, height etc or one that is not too large. There is also exact width and height constraints and a ratio too allowing for different shapes (16:9, 4:6, 5:5).

As well as the code see the updated readme file for full list of example usage.