### PR TITLE
MINOR change to prevent dimension constraint making the field required

### DIFF
--- a/code/ZenValidatorConstraint.php
+++ b/code/ZenValidatorConstraint.php
@@ -1160,6 +1160,10 @@ class Constraint_dimension extends ZenValidatorConstraint
                     }
                 }
             }
+        } else {
+            // Return true so if no file selected then not shown validation message
+            // when the field is optional. If required dev should add to required fields as well.
+            return true;
         }
     }
 


### PR DESCRIPTION
A colleague discovered the dimension constraint was showing the validation message on page save even if no file selected. The image field was optional on this page.

Did minor change so that if no file is selected this does not happen. Dev should also add the field to the required fields if required.