### PR TITLE
Validation logic bugfix

### DIFF
--- a/code/ZenValidatorFormFieldExtension.php
+++ b/code/ZenValidatorFormFieldExtension.php
@@ -5,15 +5,10 @@ use SilverStripe\Core\Extension;
 class ZenValidatorFormFieldExtension extends Extension
 {
 
-    /**
-     * @var ValidationLogicCriteria
-     **/
-    private $validationLogicCriteria;
-
 
     public function validateIf($master)
     {
-        return $this->validationLogicCriteria = ValidationLogicCriteria::create($this->owner, $master);
+        return $this->owner->validationLogicCriteria = ValidationLogicCriteria::create($this->owner, $master);
     }
 
 
@@ -27,7 +22,7 @@ class ZenValidatorFormFieldExtension extends Extension
     {
         $return = true;
 
-        if ($criteria = $this->validationLogicCriteria) {
+        if ($criteria = $this->owner->validationLogicCriteria) {
             $fields = $this->owner->rootFieldList();
             if (eval($criteria->phpEvalString()) === false) {
                 throw new Exception("There is a syntax error in the constaint logic phpEvalString \"{$criteria->phpEvalString()}\"");


### PR DESCRIPTION
Fixes a fairly big issue with the validation logic side, in that previously any validateIf's set would be set for all fields (specifically, the last validateIf would take precedence, overwritting previous validateIf's), as it used the private property of the extension class, not setting it on the FormField (->owner)