### PR TITLE
SS4 - The value of the variable is overwritten immediately

### DIFF
--- a/code/ZenValidatorConstraint.php
+++ b/code/ZenValidatorConstraint.php
@@ -660,7 +660,7 @@ class Constraint_remote extends ZenValidatorConstraint
         if (Director::is_relative_url($url)) {
             $url = Director::makeRelative($url);
             $postVars = $this->method == 'POST' ? $this->params : null;
-            $response = Director::test($url, $postVars = null, Controller::curr()->getSession(), $this->method);
+            $response = Director::test($url, $postVars, Controller::curr()->getSession(), $this->method);
             $result = ($response->getStatusCode() == 200) ? true : false;
 
             // Otherwise CURL to remote url


### PR DESCRIPTION
Hi @sheadawson,

We use your module quite extensively on one of our projects.
This pull request addresses and issue with `Constraint_remote::validate()` where null is passed instead of posted values.
Can you also create an SS3 compatible release for this fix.

Thanks!