### PR TITLE
Add class imports for validation logic

### DIFF
--- a/code/ValidationLogicCriteria.php
+++ b/code/ValidationLogicCriteria.php
@@ -1,5 +1,6 @@
 <?php
 
+use SilverStripe\Forms\FormField;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Injector\Injectable;
 /**
@@ -61,7 +62,6 @@ class ValidationLogicCriteria
      */
     public function __construct(FormField $slave, $master, $parent = null)
     {
-        parent::__construct();
         $this->slave = $slave;
         $this->master = $master;
         $this->parent = $parent;

--- a/code/ValidationLogicCriterion.php
+++ b/code/ValidationLogicCriterion.php
@@ -1,5 +1,8 @@
 <?php
 
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Core\Injector\Injectable;
+
 /**
  * @package ZenValidator
  * @license BSD License http://www.silverstripe.org/bsd-license
@@ -10,6 +13,7 @@
 class ValidationLogicCriterion
 {
 
+    use Injectable;
 
     /**
      * The name of the form field that is controlling the Validation
@@ -56,7 +60,6 @@ class ValidationLogicCriterion
      */
     public function __construct($master, $operator, $value, ValidationLogicCriteria $set)
     {
-        parent::__construct();
         $this->master = $master;
         $this->operator = $operator;
         $this->value = $value;


### PR DESCRIPTION
In namespaced SilverStripe 4 projects, using `validateIf` causes an error because of missing class imports.

```php
public function getCMSFields()
{
    $fields = parent::getCMSFields();

    $myField = TextField::create('MyField', 'My field');

    $fields->addFieldsToTab('Root.Main', [
        $myField,
        CheckboxField::create('HideMyField', 'Hide my field')
    ]);

    $myField->validateIf('HideMyField')->isEmpty();

    return $fields;
}
```

The error is...

![Screen Shot 2019-09-19 at 1 15 18 PM](https://user-images.githubusercontent.com/878176/65206357-6f859400-dae2-11e9-8475-51752d6e05ff.png)

This is happening because `FormField` is not imported in `ValidationLogicCriteria`