### PR TITLE
getSession() method does not exist in controller

### DIFF
--- a/code/ZenValidatorConstraint.php
+++ b/code/ZenValidatorConstraint.php
@@ -666,7 +666,7 @@ class Constraint_remote extends ZenValidatorConstraint
         if (Director::is_relative_url($url)) {
             $url = Director::makeRelative($url);
             $postVars = $this->method == 'POST' ? $this->params : null;
-            $response = Director::test($url, $postVars, Controller::curr()->getSession(), $this->method);
+            $response = Director::test($url, $postVars, Controller::curr()->getRequest()->getSession(), $this->method);
             $result = ($response->getStatusCode() == 200) ? true : false;
 
             // Otherwise CURL to remote url


### PR DESCRIPTION
Should call `getSession()` from `HTTPRequest` instead of `Controller`