### PR TITLE
Improving Constraint_check

### DIFF
--- a/code/ZenValidatorConstraint.php
+++ b/code/ZenValidatorConstraint.php
@@ -379,7 +379,12 @@ class Constraint_check extends ZenValidatorConstraint
 
     public function validate($value)
     {
-        $array = array_filter(explode(',', $value));
+        if (is_string($value)) {
+            $array = array_filter(explode(',', $value));
+        } else {
+            $array = $value;
+        }
+        
         if (empty($array)) {
             return; //you should use required instead
         }


### PR DESCRIPTION
Validating check always expect string in `$value`. This fix is also accept arrays.